### PR TITLE
Configurar path mappings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,18 @@
-module.exports = function(api) {
-  api.cache(true);
+module.exports = function (api) {
+  api.cache(true)
   return {
     presets: ['babel-preset-expo'],
-  };
-};
+    plugins: [
+      [
+        'module-resolver',
+        {
+          root: '.',
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+          alias: {
+            '@shared': './src/shared',
+          },
+        },
+      ],
+    ],
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,7 @@ module.exports = function (api) {
           extensions: ['.js', '.jsx', '.ts', '.tsx'],
           alias: {
             '@shared': './src/shared',
+            '@modules': './src/modules',
           },
         },
       ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,9 @@ module.exports = function (api) {
           alias: {
             '@shared': './src/shared',
             '@modules': './src/modules',
+            // Para adicionar novos path mappings, lembre-se
+            // também de alterar o tsconfig.json para que o editor
+            // de texto reconheça os mapeamentos
           },
         },
       ],

--- a/src/modules/login/pages/Login.tsx
+++ b/src/modules/login/pages/Login.tsx
@@ -1,15 +1,17 @@
-import { View, Text } from 'react-native'
+import { View } from 'react-native'
 
-import { FormField } from '../../../shared/ui/components/FormField'
-import { TextBox } from '../../../shared/ui/components/TextBox'
-import { TextButtonUnderline } from '../../../shared/ui/components/TextButton'
-import { globalStyles } from '../../../shared/ui/globalStyles'
-import { PrimaryButton } from '../../../shared/ui/components/PrimaryButton'
-import { PasswordTextBox } from '../../../shared/ui/components/PasswordTextBox'
+import {
+  FormField,
+  TextBox,
+  TextButtonUnderline,
+  PrimaryButton,
+  PasswordTextBox,
+  StyledText,
+} from '@shared/ui/components'
+import { globalStyles } from '@shared/ui/globalStyles'
 import { useState } from 'react'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { RouteParams } from '../../../routeParams'
-import { StyledText } from '../../../shared/ui/components/StyledText'
 
 type LoginForm = {
   email: string

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,13 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+
+import { LIGHT_BLACK, LIGHT_GREY } from '@shared/ui/colors'
+import { StyledText } from '@shared/ui/components'
+import { globalStyles } from '@shared/ui/globalStyles'
+
+import { StyleSheet, TouchableOpacity, View } from 'react-native'
+
 import { MyHealthModule } from '../modules'
 import { RouteParams } from '../routeParams'
-import { LIGHT_BLACK, LIGHT_GREY } from '../shared/ui/colors'
-import { globalStyles } from '../shared/ui/globalStyles'
-import { StyledText } from '../shared/ui/components/StyledText'
 
 type HomeProps = NativeStackScreenProps<RouteParams, 'Home'>
 

--- a/src/shared/ui/components/index.ts
+++ b/src/shared/ui/components/index.ts
@@ -1,0 +1,6 @@
+export * from './PasswordTextBox'
+export * from './FormField'
+export * from './PrimaryButton'
+export * from './StyledText'
+export * from './TextBox'
+export * from './TextButton'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@shared/*": ["src/shared/*"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "strict": true,
     "baseUrl": "./",
     "paths": {
-      "@shared/*": ["src/shared/*"]
+      "@shared/*": ["src/shared/*"],
+      "@modules/*": ["src/modules/*"]
     }
   }
 }


### PR DESCRIPTION
Resolve #13 

Agora é possível fazer imports absolutos para puxar o código das pastas `modules` e `shared`, deixando a nossa seção de imports mais limpa 🧼 